### PR TITLE
Add optional receipt cropping for OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ BilboT is a Telegram bot that helps you manage receipts by storing photos and as
   - Per-user limit: 1 message per 10 seconds
   - Global limit: 60 messages per minute across all users
 - Debug mode for restricted access and development
+- Optional cropping and deskewing of receipt images for better OCR
 
 ## Setup
 
@@ -100,6 +101,7 @@ BilboT can analyze receipt images using either an Ollama model or ChatGPT's visi
 2. Identify individual items and their prices
 3. Recognize store names and payment methods
 4. Structure the data for easy retrieval
+5. Optionally crop and deskew receipts before analysis for improved OCR
 
 The AI processing happens automatically when you send a receipt image. The structured data is then stored in the database for future reference.
 If you select the ChatGPT backend, ensure the `OPENAI_API_KEY` environment variable is set. You can test the processor directly with:

--- a/bilbot/utils/image_preprocessing.py
+++ b/bilbot/utils/image_preprocessing.py
@@ -34,11 +34,14 @@ def preprocess_image(
         image_path: str,
         output_path: Optional[str] = None,
         *,
-        allow_rotation: bool = False
+        allow_rotation: bool = False,
+        crop: bool = False,
 ) -> str:
     """
     One-shot preprocessing routine with advanced contour detection and perspective transformation.
     Simplified implementation based on OpenCV contour detection and perspective transform.
+    When ``crop`` is True the receipt is cropped and deskewed using the
+    detected contour which helps subsequent OCR steps.
     """
     if output_path is None:
         stem, ext = os.path.splitext(image_path)
@@ -52,7 +55,10 @@ def preprocess_image(
         scale = MAX_WIDTH / img.shape[1]
         img = cv2.resize(img, None, fx=scale, fy=scale, interpolation=cv2.INTER_AREA)
     
-    # Apply deskew/perspective transform if allowed
+    if crop:
+        allow_rotation = True  # cropping implies perspective transform
+
+    # Apply deskew/perspective transform if allowed (also used for cropping)
     if allow_rotation:
         # Convert to grayscale
         gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)

--- a/bilbot/utils/image_utils.py
+++ b/bilbot/utils/image_utils.py
@@ -103,7 +103,7 @@ def get_receipt_image_path(user_id, chat_id, message_id, received_date):
     # We don't know the exact timestamp in the filename, so return the directory
     return date_path
 
-def preprocess_receipt_image(image_path):
+def preprocess_receipt_image(image_path, *, crop: bool = False):
     """
     Apply image preprocessing techniques to enhance receipt image for better OCR results.
     
@@ -115,10 +115,10 @@ def preprocess_receipt_image(image_path):
     """
     try:
         logger.info(f"Starting image preprocessing for OCR enhancement: {image_path}")
-        
-        # Skip rotation/deskewing as requested
-        # Apply preprocessing enhancements directly to the original image
-        preprocessed_path = preprocess_image(image_path)
+
+        # When crop=True the image will be cropped and deskewed to
+        # make text extraction more reliable.
+        preprocessed_path = preprocess_image(image_path, allow_rotation=crop, crop=crop)
         logger.info(f"Preprocessing completed: {preprocessed_path}")
         
         return preprocessed_path
@@ -141,8 +141,8 @@ async def process_and_save_receipt_data(receipt_id, image_path):
     try:
         logger.info(f"Processing receipt image for receipt_id {receipt_id}: {image_path}")
         
-        # Apply preprocessing to enhance image quality for OCR
-        preprocessed_image = preprocess_receipt_image(image_path)
+        # Apply preprocessing to enhance image quality for OCR and crop the receipt
+        preprocessed_image = preprocess_receipt_image(image_path, crop=True)
         logger.info(f"Using preprocessed image: {preprocessed_image}")
         
         # Choose AI backend

--- a/tests/test_image_preprocessing.py
+++ b/tests/test_image_preprocessing.py
@@ -76,6 +76,7 @@ def main():
     parser = argparse.ArgumentParser(description="Test image preprocessing for OCR")
     parser.add_argument("image_path", help="Path to the receipt image to preprocess")
     parser.add_argument("--allow-rotation", action="store_true", help="Allow image rotation/deskewing")
+    parser.add_argument("--crop", action="store_true", help="Crop receipt before enhancement")
     args = parser.parse_args()
     
     if not os.path.exists(args.image_path):
@@ -86,7 +87,11 @@ def main():
     
     # Apply preprocessing directly without deskewing step unless explicitly allowed
     print("Enhancing image...")
-    preprocessed_path = preprocess_image(args.image_path, allow_rotation=args.allow_rotation)
+    preprocessed_path = preprocess_image(
+        args.image_path,
+        allow_rotation=args.allow_rotation or args.crop,
+        crop=args.crop,
+    )
     
     # Create comparison
     print("Creating comparison image...")


### PR DESCRIPTION
## Summary
- add `crop` option to image preprocessing helper
- allow cropping in receipt preprocessing and apply it by default
- expose cropping option in the preprocessing test script
- document cropping in README

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68474d3a482083328b1d464297806a6a