### PR TITLE
Improve polling stability

### DIFF
--- a/bilbot.py
+++ b/bilbot.py
@@ -42,8 +42,16 @@ async def main():
         logger.error("Failed to retrieve bot token from keyring")
         return
 
-    # Create the Application and pass it the bot token
-    application = Application.builder().token(token).build()
+    # Create the Application with slightly relaxed timeouts to mitigate
+    # occasional network read errors during polling
+    application = (
+        Application.builder()
+        .token(token)
+        .connect_timeout(10.0)
+        .read_timeout(10.0)
+        .http_version("1.1")
+        .build()
+    )
 
     # Initialize the database
     init_database()


### PR DESCRIPTION
## Summary
- mitigate network read errors when polling by customizing `Application` with longer timeouts and HTTP/1.1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475a49eefc8332aac5a8391c754ad0